### PR TITLE
bug fix. AutoMetadata may contain Map or List

### DIFF
--- a/java/org/patricbrc/Workspace/ObjectMeta.java
+++ b/java/org/patricbrc/Workspace/ObjectMeta.java
@@ -38,7 +38,7 @@ public class ObjectMeta
     public String object_owner;
     public Integer e_7;
     public Map<String, String> e_8;
-    public Map<String, String> e_9;
+    public Map<String, Object> e_9;
     public String user_permission;
     public String global_permission;
     public String shockurl;

--- a/java/org/patricbrc/Workspace/ObjectMeta_deserializer.java
+++ b/java/org/patricbrc/Workspace/ObjectMeta_deserializer.java
@@ -28,7 +28,7 @@ public class ObjectMeta_deserializer extends JsonDeserializer<ObjectMeta>
 	res.object_owner = p.readValueAs(String.class);
 	res.e_7 = p.readValueAs(Integer.class);
 	res.e_8 = p.readValueAs(new TypeReference<Map<String, String>>(){});
-	res.e_9 = p.readValueAs(new TypeReference<Map<String, String>>(){});
+	res.e_9 = p.readValueAs(new TypeReference<Map<String, Object>>(){});
 	res.user_permission = p.readValueAs(String.class);
 	res.global_permission = p.readValueAs(String.class);
 	res.shockurl = p.readValueAs(String.class);


### PR DESCRIPTION
I found a bug when I request for a experiment object, which contains map and list in the autometadata. Please consider this change.