### PR TITLE
add rxnprobs file type

### DIFF
--- a/typeslist.txt
+++ b/typeslist.txt
@@ -41,6 +41,7 @@ ppt
 pptx
 proteomics_experiment
 reads
+rxnprobs
 string
 svg
 tar_gz


### PR DESCRIPTION
A rxnprobs file contains reaction probabilities generated by the probabilistic annotation algorithm and are input to the GapfillModel() method in ProbModelSEED.