### PR TITLE
fix collapse multiple slashes in paths

### DIFF
--- a/lib/Bio/P3/Workspace/WorkspaceImpl.pm
+++ b/lib/Bio/P3/Workspace/WorkspaceImpl.pm
@@ -380,6 +380,7 @@ sub _parse_ws_path {
 		return ($wsobj->{owner},$wsobj->{name},$2,$3);
 	}
 	#/<username>/<workspace>
+	$input =~ s/\/+/\//g;
 	if ($input =~ m/^\/([^\/]+)\/([^\/]+)\/*$/) {
 		return ($1,$2,"","");
 	}


### PR DESCRIPTION
Multiple forward slashes in a workspace path produce inconsistent results.  Two slashes do not produce an error:

    > ws-ls /mmundy//home
    Name    Owner  Type   Moddate             Size User perm Global perm
    Genomes mmundy folder 2015-05-22T20:18:40 0    o         n          
    models  mmundy folder 2015-06-03T16:41:57 0    o         n 

But more than two slashes produce this error:

    > ws-ls /mmundy///home
    Error running ls
    JSONRPC error:
    _ERROR_User lacks permission to / for requested action!_ERROR_

I found the problem when the cache in the PATRICStore in ProbModelSEED was not working correctly when the input path contained a double slash.