### PR TITLE
Fix zero-size update bug

### DIFF
--- a/lib/Bio/P3/Workspace/WorkspaceImpl.pm
+++ b/lib/Bio/P3/Workspace/WorkspaceImpl.pm
@@ -435,7 +435,7 @@ sub _get_directory_contents {
 
 #Retrive objects from mongodb based on input query**
 sub _query_database {
-	my ($self,$query,$count) = @_;
+	my ($self,$query,$count,$update_shock) = @_;
 	if (defined($query->{path})) {
 		$query->{path} =~ s/^\///;
 		$query->{path} =~ s/\/$//;
@@ -449,7 +449,7 @@ sub _query_database {
 	while (my $object = $cursor->next) {
 		$object->{wsobj} = $self->_wscache("_uuid",$object->{workspace_uuid});
 		if ($object->{shock} == 1 && $object->{size} == 0) {			
-			$self->_update_shock_node($object);
+			$self->_update_shock_node($object,$update_shock);
 		}
 		if (defined($hash->{$object->{workspace_uuid}}->{$object->{path}}->{$object->{name}})) {
 			for (my $i=0; $i < @{$output}; $i++) {
@@ -993,7 +993,7 @@ sub _list_objects {
 	} else {
 		$query->{path} = $path;
 	}
-	return $self->_query_database($query,0);
+	return $self->_query_database($query,0, 1);
 }
 
 #Formating queries to support direct mongo queries - this will need to get far more sophisticated**


### PR DESCRIPTION
Chris, please take a look at this for sanity's sake

[7/21/15, 12:21:12 PM] olsonanl: What has changed is that the workspace file listing query will always query shock for updated size if the file is in shock and it has a zero size in the workspace metadata
[7/21/15, 12:21:48 PM] olsonanl: what was happening before is that if one query happened when the file was still uploading and got the not-uploaded-yet response, a 30 minute timer was set before another attempt at update was made
[7/21/15, 12:22:34 PM] olsonanl: the reason we sometimes got a result was if a different workspace service instance was routed to by the proxy, whcih didn’t have that state of “i tried to look up but got zero so I have to wait 30  minutes”, checked for an update, and got a value
