### PR TITLE
Work around problem with broken workspace files.

### DIFF
--- a/lib/Bio/P3/Workspace/WorkspaceImpl.pm
+++ b/lib/Bio/P3/Workspace/WorkspaceImpl.pm
@@ -580,6 +580,11 @@ sub _make_shock_node_public {
 
 sub _update_shock_node {
 	my ($self,$object,$force) = @_;
+        if ($object->{shocknode} !~ /[0-9a-f]$/i)
+	{
+	    warn "Bad workspace obj: bogus shock node " . Dumper($object);
+	    return;
+	}
 	if ($force == 1 ||
 	    !defined($self->{_shockupdate}->{$object->{uuid}}) ||
 	    (time() - $self->{_shockupdate}->{$object->{uuid}}) > $self->{_params}->{"update-interval"}) {


### PR DESCRIPTION
A user had several workspace files that had bad state shock = 1 but shocknode had no node id. This results in an enumeration of all visible shock nodes followed by a crash due to unexpected format of the returned data. This PR works around the problem.

Bad workspace obj: bogus shock node $VAR1 = {
          'owner' => 'gwillsey@patricbrc.org',
          'shocknode' => 'https://p3.theseed.org/services/shock_api/node/',
          '_id' => bless( {
                          'value' => '570dacc0fc65212743549e0a'
                        }, 'MongoDB::OID' ),
          'name' => 'MERO_75_R1.fq.gz',
          'shock' => 1,
          'path' => '',
          'autometadata' => {},
          'uuid' => '2FAAC09A-011E-11E6-81D4-2FC1682E0674',
          'size' => 0,
          'folder' => 0,
          'wsobj' => {
                       'owner' => 'gwillsey@patricbrc.org',
                       'global_permission' => 'n',
                       'creation_date' => '2016-03-21T17:35:49',
                       'permissions' => {},
                       '_id' => bless( {
                                       'value' => '56f030f5fc65211d38481f2c'
                                     }, 'MongoDB::OID' ),
                       'name' => 'home',
                       'metadata' => {},
                       'uuid' => '5A26A1EE-EF8B-11E5-A5FE-24B7682E0674'
                     },
          'creation_date' => '2016-04-13T02:19:44',
          'type' => 'reads',
          'metadata' => {},
          'workspace_uuid' => '5A26A1EE-EF8B-11E5-A5FE-24B7682E0674'
        };
